### PR TITLE
Allow users to name backups when calling dumpdb

### DIFF
--- a/src/m2ee.py
+++ b/src/m2ee.py
@@ -564,7 +564,14 @@ class CLI(cmd.Cmd):
         if not self.m2ee.config.is_using_postgresql():
             logger.error("Only PostgreSQL databases are supported right now.")
             return
-        pgutil.dumpdb(self.m2ee.config)
+        if len(args.split()) == 0:
+            pgutil.dumpdb(self.m2ee.config)
+        elif len(args.split()) == 1:
+            pgutil.dumpdb(self.m2ee.config, args)
+        else:
+            print args.split()
+            logger.error("This command only takes one argument.")
+            return
 
     def do_restoredb(self, args):
         if not self.m2ee.config.is_using_postgresql():

--- a/src/m2ee/pgutil.py
+++ b/src/m2ee/pgutil.py
@@ -12,17 +12,15 @@ import time
 from log import logger
 
 
-def dumpdb(config):
+def dumpdb(config, name=None):
 
     env = os.environ.copy()
     env.update(config.get_pg_environment())
 
-    db_dump_file_name = (
-        os.path.join(
-            config.get_database_dump_path(), "%s_%s.backup" %
-            (env['PGDATABASE'], time.strftime("%Y%m%d_%H%M%S"))
-        )
-    )
+    if name is None:
+        name =  "%s_%s.backup" % (env['PGDATABASE'], time.strftime("%Y%m%d_%H%M%S"))
+
+    db_dump_file_name = os.path.join(config.get_database_dump_path(), name)
 
     logger.info("Writing database dump to %s" % db_dump_file_name)
     cmd = (config.get_pg_dump_binary(), "-O", "-x", "-F", "c")


### PR DESCRIPTION
The default name doesn't always make sense for users, sometimes you want
to explicitly specify a name upfront. Add an optional argument to dumpdb
for this. Defaults back to old behavior.
