### PR TITLE
Fix incorrect JVM graph values for Mx <6.6, <5.21.5

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+m2ee-tools 0.5.11.3, 26 Jul 2016
+  * Fix incorrect JVM graph values for Mx <6.6, <5.21.5, MemoryPoolMXBean values
+    show up in a different order when running Java 8.
+
 m2ee-tools 0.5.11.2, 19 Nov 2015
   * Disable runtime_blocking_connector by default, it's buggy and closes connections
     that are waiting for a response.

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+m2ee-tools 0.5.11.3, 26 Jul 2016
+================================
+
+Previous m2ee versions showed incorrect values for JVM graphs for the following
+Mendix versions when using Java 8: (>=6 && < 6.6) || (>=5.18 && <= 5.21.5)
+
+The MemoryPoolMXBean values show up in a different order when running Java 8.
+
 m2ee-tools 0.5.11.2, 19 Nov 2015
 ================================
 

--- a/src/m2ee/__init__.py
+++ b/src/m2ee/__init__.py
@@ -6,4 +6,4 @@ import munin  # noqa
 import version  # noqa
 from profile import M2EEProfiler  # noqa
 
-__version__ = '0.5.11.2'
+__version__ = '0.5.11.3'

--- a/src/m2ee/munin.py
+++ b/src/m2ee/munin.py
@@ -88,7 +88,7 @@ default_stats = {
 
 
 def print_config(m2ee, name):
-    stats = get_stats('config', m2ee.client, m2ee.config)
+    stats, java_version = get_stats('config', m2ee.client, m2ee.config)
     if stats is None:
         return
     options = m2ee.config.get_munin_options()
@@ -104,7 +104,7 @@ def print_config(m2ee, name):
 
 
 def print_values(m2ee, name):
-    stats = get_stats('values', m2ee.client, m2ee.config)
+    stats, java_version = get_stats('values', m2ee.client, m2ee.config)
     if stats is None:
         return
     options = m2ee.config.get_munin_options()
@@ -116,7 +116,25 @@ def print_values(m2ee, name):
     print_threadpool_values(name, stats)
     print_cache_values(name, stats)
     print_jvm_threads_values(name, stats)
-    print_jvm_process_memory_values(name, stats, m2ee.runner.get_pid())
+    print_jvm_process_memory_values(name, stats, m2ee.runner.get_pid(), m2ee.client, java_version)
+
+
+def guess_java_version(client, runtime_version, stats):
+    m2eeresponse = client.about()
+    if not m2eeresponse.has_error():
+        about = m2eeresponse.get_feedback()
+        if 'java_version' in about:
+            java_version = about['java_version']
+            java_major, java_minor, _ = java_version.split('.')
+            return int(java_minor)
+    if runtime_version // 6:
+        return 8
+    if runtime_version // 5:
+        m = stats['memory']
+        if m['used_nonheap'] - m['code'] - m['permanent'] == 0:
+            return 7
+        return 8
+    return None
 
 
 def get_stats(action, client, config):
@@ -129,8 +147,9 @@ def get_stats(action, client, config):
 
     # TODO: even better error/exception handling
     stats = None
+    java_version = None
     try:
-        stats = get_stats_from_runtime(client, config)
+        stats, java_version = get_stats_from_runtime(client, config)
         write_last_known_good_stats_cache(stats, config_cache)
     except Exception, e:
         if action == 'config':
@@ -142,7 +161,7 @@ def get_stats(action, client, config):
             # assume something bad happened, like
             # socket.error: [Errno 111] Connection refused
             logger.error("Error fetching runtime/server statstics: %s", e)
-    return stats
+    return stats, java_version
 
 
 def get_stats_from_runtime(client, config):
@@ -167,7 +186,32 @@ def get_stats_from_runtime(client, config):
         if not m2eeresponse.has_error():
             stats['threads'] = len(m2eeresponse.get_feedback())
 
-    return stats
+    java_version = guess_java_version(client, runtime_version, stats)
+    if 'memorypools' in stats['memory']:
+        memorypools = stats['memory']['memorypools']
+        if java_version == 7:
+            stats['memory']['code'] = memorypools[0]['usage']
+            stats['memory']['permanent'] = memorypools[4]['usage']
+            stats['memory']['eden'] = memorypools[1]['usage']
+            stats['memory']['survivor'] = memorypools[2]['usage']
+            stats['memory']['tenured'] = memorypools[3]['usage']
+        else:
+            stats['memory']['code'] = memorypools[0]['usage']
+            stats['memory']['permanent'] = memorypools[2]['usage']
+            stats['memory']['eden'] = memorypools[3]['usage']
+            stats['memory']['survivor'] = memorypools[4]['usage']
+            stats['memory']['tenured'] = memorypools[5]['usage']
+    elif java_version >= 8:
+        memory = stats['memory']
+        metaspace = memory['eden']
+        eden = memory['tenured']
+        survivor = memory['permanent']
+        old = memory['used_heap'] - eden - survivor
+        memory['permanent'] = metaspace
+        memory['eden'] = eden
+        memory['survivor'] = survivor
+        memory['tenured'] = old
+    return stats, java_version
 
 
 def write_last_known_good_stats_cache(stats, config_cache):
@@ -497,7 +541,7 @@ def print_jvm_process_memory_config(name):
     print("")
 
 
-def print_jvm_process_memory_values(name, stats, pid):
+def print_jvm_process_memory_values(name, stats, pid, client, java_version):
     if pid is None:
         return
     totals = smaps.get_smaps_rss_by_category(pid)
@@ -511,14 +555,23 @@ def print_jvm_process_memory_values(name, stats, pid):
     javaheap = totals[smaps.CATEGORY_JVM_HEAP] * 1024
     for k in ['tenured', 'survivor', 'eden']:
         print('%s.value %s' % (k, memory[k]))
-    print("javaheap.value %s" % (javaheap - memory['used_heap'] - memory['used_nonheap']))
-    print("permanent.value %s" % memory['permanent'])
-    print("codecache.value %s" % memory['code'])
+    if java_version is not None and java_version >= 8:
+        print("javaheap.value %s" % (javaheap - memory['used_heap'] - memory['code']))
+    else:
+        print("javaheap.value %s" %
+              (javaheap - memory['used_heap'] - memory['code'] - memory['permanent']))
 
     nativemem = totals[smaps.CATEGORY_NATIVE_HEAP_ARENA] * 1024
-    print("nativemem.value %s" % nativemem)
+    othermem = totals[smaps.CATEGORY_OTHER] * 1024
+    print("permanent.value %s" % memory['permanent'])
+    print("codecache.value %s" % memory['code'])
+    if java_version is not None and java_version >= 8:
+        print("nativemem.value %s" % (nativemem + othermem - memory['permanent']))
+        print("other.value 0")
+    else:
+        print("nativemem.value %s" % nativemem)
+        print("other.value %s" % othermem)
 
     print("stacks.value %s" % (totals[smaps.CATEGORY_THREAD_STACK] * 1024))
-    print("other.value %s" % (totals[smaps.CATEGORY_OTHER] * 1024))
     print("total.value %s" % (sum(totals.values()) * 1024))
     print("")


### PR DESCRIPTION
This change fixes incorrect values for JVM graphs for the following
Mendix versions when using Java 8:
  (>=6 && < 6.6) || (>=5.18 && <= 5.21.5)

The MemoryPoolMXBean values show up in a different order when running java8.
And since memorypools is not availabe for <= Mx6.5, let's reconstruct it ourselves.

  | java7     | java8
--+-----------+-----------------
0 | code      | code
1 | eden      | metaspace
2 | survivor  | compressed class
3 | tenured   | eden
4 | permanent | survivor
5 | -         | tenured

If Mendix 6 then always assume Java 8, so tetris the values into the
right spot and calculate old (tenured), which is missing in the
statistics call result.

If Mendix 5, then see if used_nonheap is the exact sum of code and
permanent. If so, then Java 7, else Java 8.

Also, move memorypools code out of the threads handling code, it makes
no sense to put it below those conditions.