### PR TITLE
fix hanging check_mxruntime_health nagios check

### DIFF
--- a/src/m2ee/client.py
+++ b/src/m2ee/client.py
@@ -195,8 +195,8 @@ class M2EEClient:
     def get_log_settings(self, params):
         return self.request("get_log_settings", params)
 
-    def check_health(self, params=None):
-        return self.request("check_health", params)
+    def check_health(self, params=None, timeout=None):
+        return self.request("check_health", params, timeout)
 
     def get_current_runtime_requests(self):
         return self.request("get_current_runtime_requests")

--- a/src/m2ee/nagios.py
+++ b/src/m2ee/nagios.py
@@ -106,9 +106,9 @@ def check_process(runner, client):
     return (state, message)
 
 
-def check_health(client):
+def check_health(client, timeout=60):
     try:
-        feedback = client.check_health()
+        feedback = client.check_health(timeout=timeout)
         if feedback['health'] == 'healthy':
             return STATE_OK, "Healty"
         elif feedback['health'] == 'sick':


### PR DESCRIPTION
If runtime admin port did not respond, the check would hang. Checks
would keep piling up, leading to OOMing systems.

This introduces a default timeout of 60 seconds. Alternatively, a
ping could be done before checking the health, but a timeout is still
needed for edge cases.