### PR TITLE
adding the --clean --if-exists options to pg_restore

### DIFF
--- a/src/m2ee/pgutil.py
+++ b/src/m2ee/pgutil.py
@@ -46,7 +46,7 @@ def restoredb(config, dump_name):
     )
     logger.debug("Restoring %s" % db_dump_file_name)
     cmd = (config.get_pg_restore_binary(), "-d", env['PGDATABASE'],
-           "-O", "-n", "public", "-x", db_dump_file_name)
+           "--clean", "--if-exists", "-O", "-n", "public", "-x", db_dump_file_name)
     logger.trace("Executing %s" % str(cmd))
     try:
         proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE,


### PR DESCRIPTION
Adding this is "needed" when there are objects that haven't been cleared
yet like stored procedures.

Note: this is needed on the pg_restore side, as the normal m2ee dumpdb
format is the custom archive (with compression) and not the plain text,
which needs it on the pg_dump side as that gets loaded with a psql not
pg_restore